### PR TITLE
Support file paths that contain spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,20 @@ You will need to download/install a few things to make this work.
 
 ## Usage
 
-1. Ensure you check this project out in a path with _no spaces_ in the name
-   - This project is currently sensitive to this, and having spaces in any paths will mean it doesn't work.
-2. Open the Modders Multitool
+1. Open the Modders Multitool
    - Make sure you have your game path set correctly. This can be confirmed by opening the Configuration dialog from thetop menu.
-3. In the top menu, select `Utilities` > `Game File Operations` > `Unpack Game Files`.
-4. Select `SharedSoundBanks.pak` and `SharedSounds.pak` and confirm.
-5. Wait for the unpacking to complete.
-6. Back in this project, change the constants in `categoriser.py`
+2. In the top menu, select `Utilities` > `Game File Operations` > `Unpack Game Files`.
+3. Select `SharedSoundBanks.pak` and `SharedSounds.pak` and confirm.
+4. Wait for the unpacking to complete.
+5. Back in this project, change the constants in `categoriser.py`
    - `wwiser_pyz` should be the path of the `wwiser.pyz` you downloaded.
    - `folder_vgmstream` should be the folder you extracted vgmstream to.
    - `folder_unpacked_data` should be the `UnpackedData` folder in your BG3 Modders Multitool location.
    - `folder_audio_converted` should be the folder where you want your final files to be.
-7. If you want the files renamed to more human-friendly names, check the advanced section.
-8. Run `python categoriser.py`
+6. If you want the files renamed to more human-friendly names, check the advanced section.
+7. Run `python categoriser.py`
    - This will take some time, so go off and enjoy your life while it does its thing.
-9. Your audio files will be categorised in the converted folder.
+8. Your audio files will be categorised in the converted folder.
    - The file names will be numbers, not human friendly names. If you are looking for something specific, then you will need to sort through them manually.
 
 ### Advanced: Renaming

--- a/categoriser.py
+++ b/categoriser.py
@@ -30,8 +30,11 @@ def convert_wem_folder(source_dir: str, dest_dir: str):
     for wem in wems:
         _, filename = os.path.split(wem)
         subprocess.call(
-            f"vgmstream-cli -o {dest_dir}\\{filename}.wav {source_dir}\\{filename}",
-            shell=True,
+            [ "vgmstream-cli",
+                "-o",
+                os.path.join(dest_dir, f"{filename}.wav"),
+                os.path.join(source_dir, filename),
+            ],
             stdout=subprocess.DEVNULL,
         )
         wem_index = wem_index + 1
@@ -48,8 +51,7 @@ def decode_banks(source_dir: str):
     print(f"\r  {bank_index}/{total}", end="", flush=True)
     for bank in banks:
         subprocess.call(
-            f"python {wwiser_pyz} -d xsl {bank}",
-            shell=True,
+            [ "python", wwiser_pyz, "-d", "xsl", bank ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )


### PR DESCRIPTION
If directory file paths contain space characters, invoking the subprocess with `shell=True` and using a string for the command will cause failures, since it will be interpreted as two separate arguments.

Providing a list of arguments (with `shell=False`) fixes this.